### PR TITLE
Fix missing Security import

### DIFF
--- a/BatteryDrain/ContentView.swift
+++ b/BatteryDrain/ContentView.swift
@@ -6,6 +6,7 @@ import AVKit
 import ARKit
 import CoreImage
 import MetalKit
+import Security
 
 // MARK: - IntenseAnimatedView
 struct CrazyParticleBackgroundView: UIViewRepresentable {


### PR DESCRIPTION
## Summary
- add Security framework import to ContentView

## Testing
- `swift --version`
- `swiftc -parse BatteryDrain/ContentView.swift`

------
https://chatgpt.com/codex/tasks/task_e_68586df3d08883229c0dfb6ebee600cc